### PR TITLE
Build 2 images

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -42,7 +42,7 @@ jobs:
   convert:
     runs-on: ${{ inputs.runs-on }}
     outputs:
-      platforms: ${{ fromJson(steps.convert.outputs.platforms) }}
+      platforms: ${{ steps.convert.outputs.platforms }}
     steps:
       -
         name: Convert Platforms
@@ -59,13 +59,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ needs.convert.outputs.platforms }}
+        platform: ${{ fromJSON(needs.convert.outputs.platforms) }}
     steps:
       -
         name: Prepare
         id: platform
         run: |
-          platform=${{ needs.convert.outputs.platforms }}
+          platform=${{ fromJSON(needs.convert.outputs.platforms) }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
@@ -95,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ needs.convert.outputs.platforms }}
+          platforms: ${{ fromJSON(needs.convert.outputs.platforms) }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           file: ${{ inputs.file }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -32,6 +32,10 @@ on:
         required: false
         type: string
         default: 'ghcr.io'
+      build-args:
+        description: "List of build-time variables"
+        required: false
+        type: string
     secrets:
       username:
         description: 'username at registry'
@@ -39,7 +43,34 @@ on:
       password:
         description: 'password at registry'
         required: true
-
+    outputs:
+      version:
+        description: 'Generated Docker image version'
+        value: ${{ jobs.merge.outputs.version }}
+      tags:
+        description: 'Generated Docker tags'
+        value: ${{ jobs.merge.outputs.tags }}
+      labels:
+        description: 'Generated Docker labels'
+        value: ${{ jobs.merge.outputs.labels }}
+      annotations:
+        description: 'Generated annotations'
+        value: ${{ jobs.merge.outputs.annotations }}
+      json:
+        description: 'JSON output of tags and labels'
+        value: ${{ jobs.merge.outputs.json }}
+      bake-file-tags:
+        description: 'Bake definition file with tags'
+        value: ${{ jobs.merge.outputs.bake-file-tags }}
+      bake-file-labels:
+        description: 'Bake definition file with labels'
+        value: ${{ jobs.merge.outputs.bake-file-labels }}
+      bake-file-annotations:
+        description: 'Bake definiton file with annotations'
+        value: ${{ jobs.merge.outputs.bake-file-annotations }}
+      bake-file:
+        description: 'Bake definition file with tags and labels'
+        value: ${{ jobs.merge.outputs.bake-file }}
 env:
   REGISTRY_IMAGE: ${{inputs.registry }}/${{ inputs.image }}
 
@@ -113,6 +144,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           file: ${{ inputs.file }}
+          build-args: ${{ inputs.build-args }}
       -
         name: Export digest
         run: |
@@ -133,6 +165,16 @@ jobs:
     needs:
       - build
       - prepare
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+      annotations: ${{ steps.meta.outputs.annotations }}
+      json: ${{ steps.meta.outputs.json }}
+      bake-file-tags: ${{ steps.meta.outputs.bake-file-tags }}
+      bake-file-labels: ${{ steps.meta.outputs.bake-file-labels }}
+      bake-file-annotations: ${{ steps.meta.outputs.bake-file-annotations }}
+      bake-file: ${{ steps.meta.outputs.bake-file }}
     steps:
       -
         name: Download digests

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: 'linux/amd64,linux/arm64'
+      registry:
+        description: 'Registry to push to'
+        required: false
+        type: string
+        default: 'ghcr.io'
     secrets:
       username:
         description: 'username at registry'
@@ -36,13 +41,14 @@ on:
         required: true
 
 env:
-  REGISTRY_IMAGE: ${{ inputs.image }}
+  REGISTRY_IMAGE: ${{inputs.registry }}/${{ inputs.image }}
 
 jobs:
   convert:
     runs-on: ${{ inputs.runs-on }}
     outputs:
       platforms: ${{ steps.convert.outputs.platforms }}
+      run-id: ${{ steps.run-id.outputs.run-id }}
     steps:
       -
         name: Convert Platforms
@@ -50,7 +56,15 @@ jobs:
         run: |
           platforms=${{ inputs.platforms }}
           inside=$(printf %s\\n "$platforms" | sed -E -e 's/,/\", \"/g' -e 's/\" +/\"/g' -e 's/ +\"/\"/g')
-          printf 'platforms=["%s"]' "$inside" >> $GITHUB_OUTPUT
+          printf 'platforms=["%s"]\n' "$inside" >> $GITHUB_OUTPUT
+      -
+        name: Generate artifact name
+        id: run-id
+        run: |
+          random_string() {
+            LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c "${1:-12}"
+          }
+          printf 'run-id=%s\n' "$(random_string)" >> $GITHUB_OUTPUT
 
   build:
     runs-on: ${{ inputs.runs-on }}
@@ -86,7 +100,7 @@ jobs:
         name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ inputs.registry }}
           username: ${{ secrets.username }}
           password: ${{ secrets.password }}
       -
@@ -109,7 +123,7 @@ jobs:
         name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ needs.convert.outputs.run-id }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -118,13 +132,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - convert
     steps:
       -
         name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ needs.convert.outputs.run-id }}-*
           merge-multiple: true
       -
         name: Set up Docker Buildx
@@ -139,7 +154,7 @@ jobs:
         name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ inputs.registry }}
           username: ${{ secrets.username }}
           password: ${{ secrets.password }}
       -

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -42,7 +42,7 @@ jobs:
   convert:
     runs-on: ${{ inputs.runs-on }}
     outputs:
-      platforms: ${{ steps.convert.outputs.platforms }}
+      platforms: ${{ fromJson(steps.convert.outputs.platforms) }}
     steps:
       -
         name: Convert Platforms

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,7 +1,7 @@
 name: multi-platform build
 
 on:
-  worfklow_call:
+  workflow_call:
     inputs:
       image:
         description: 'Base image to build'

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -58,7 +58,7 @@ jobs:
           inside=$(printf %s\\n "$platforms" | sed -E -e 's/,/\", \"/g' -e 's/\" +/\"/g' -e 's/ +\"/\"/g')
           printf 'platforms=["%s"]\n' "$inside" >> $GITHUB_OUTPUT
       -
-        name: Generate artifact name
+        name: Generate random run identifier
         id: run-id
         run: |
           random_string() {

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,0 +1,136 @@
+name: multi-platform build
+
+on:
+  worfklow_call:
+    inputs:
+      image:
+        description: 'Base image to build'
+        required: true
+        type: string
+      file:
+        description: 'Dockerfile to use'
+        required: false
+        type: string
+        default: 'Dockerfile'
+      context:
+        description: 'Build context'
+        required: false
+        type: string
+        default: '.'
+      runs-on:
+        description: 'Runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+    secrets:
+      username:
+        description: 'username at registry'
+        required: true
+      password:
+        description: 'password at registry'
+        required: true
+
+env:
+  REGISTRY_IMAGE: ${{ inputs.image }}
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      -
+        name: Prepare
+        id: platform
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.username }}
+          password: ${{ secrets.password }}
+      -
+        name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          file: ${{ inputs.file }}
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.username }}
+          password: ${{ secrets.password }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -44,7 +44,7 @@ env:
   REGISTRY_IMAGE: ${{inputs.registry }}/${{ inputs.image }}
 
 jobs:
-  convert:
+  prepare:
     runs-on: ${{ inputs.runs-on }}
     outputs:
       platforms: ${{ steps.convert.outputs.platforms }}
@@ -69,11 +69,11 @@ jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     needs:
-      - convert
+      - prepare
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(needs.convert.outputs.platforms) }}
+        platform: ${{ fromJSON(needs.prepare.outputs.platforms) }}
     steps:
       -
         name: Prepare
@@ -123,7 +123,7 @@ jobs:
         name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ needs.convert.outputs.run-id }}-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ needs.prepare.outputs.run-id }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -132,14 +132,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - convert
+      - prepare
     steps:
       -
         name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ needs.convert.outputs.run-id }}-*
+          pattern: digests-${{ needs.prepare.outputs.run-id }}-*
           merge-multiple: true
       -
         name: Set up Docker Buildx

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      platforms:
+        description: 'Platforms to build for, comma separated list of arch/os pairs'
+        required: false
+        type: string
+        default: 'linux/amd64,linux/arm64'
     secrets:
       username:
         description: 'username at registry'
@@ -34,20 +39,33 @@ env:
   REGISTRY_IMAGE: ${{ inputs.image }}
 
 jobs:
+  convert:
+    runs-on: ${{ inputs.runs-on }}
+    outputs:
+      platforms: ${{ steps.convert.outputs.platforms }}
+    steps:
+      -
+        name: Convert Platforms
+        id: convert
+        run: |
+          platforms=${{ inputs.platforms }}
+          inside=$(printf %s\\n "$platforms" | sed -E -e 's/,/\", \"/g' -e 's/\" +/\"/g' -e 's/ +\"/\"/g')
+          printf 'platforms=["%s"]' "$inside" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ${{ inputs.runs-on }}
+    needs:
+      - convert
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        platform: ${{ needs.convert.outputs.platforms }}
     steps:
       -
         name: Prepare
         id: platform
         run: |
-          platform=${{ matrix.platform }}
+          platform=${{ needs.convert.outputs.platforms }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
@@ -77,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ needs.convert.outputs.platforms }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           file: ${{ inputs.file }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -65,7 +65,7 @@ jobs:
         name: Prepare
         id: platform
         run: |
-          platform=${{ fromJSON(needs.convert.outputs.platforms) }}
+          platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
@@ -95,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ fromJSON(needs.convert.outputs.platforms) }}
+          platforms: ${{ inputs.platforms }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           file: ${{ inputs.file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,22 @@ on:
       - feature/build-two-images
 
 jobs:
-  build:
+  build-base:
     uses: ./.github/workflows/_build.yml
     with:
       image: ghcr.io/${{ github.actor }}/runner-krunvm-base
       file: Dockerfile.base
+    secrets:
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
+
+  build-main:
+    needs:
+      - build-base
+    uses: ./.github/workflows/_build.yml
+    with:
+      image: ghcr.io/${{ github.actor }}/runner-krunvm
+      file: Dockerfile
     secrets:
       username: ${{ github.actor }}
       password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,109 +3,15 @@ name: ci
 on:
   push:
     branches:
-      - "main"
-
-env:
-  REGISTRY_IMAGE: ghcr.io/${{ github.actor }}/runner-krunvm-base
+      - main
+      - feature/build-two-images
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-    steps:
-      -
-        name: Prepare
-        id: platform
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          file: Dockerfile.base
-      -
-        name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      -
-        name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      -
-        name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-      -
-        name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      -
-        name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+    uses: ./.github/workflows/_build.yml
+    with:
+      image: ghcr.io/${{ github.actor }}/runner-krunvm-base
+      file: Dockerfile.base
+    secrets:
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build-base:
     uses: ./.github/workflows/_build.yml
     with:
-      image: ghcr.io/${{ github.actor }}/runner-krunvm-base
+      image: ${{ github.actor }}/runner-krunvm-base
       file: Dockerfile.base
     secrets:
       username: ${{ github.actor }}
@@ -21,7 +21,7 @@ jobs:
       - build-base
     uses: ./.github/workflows/_build.yml
     with:
-      image: ghcr.io/${{ github.actor }}/runner-krunvm
+      image: ${{ github.actor }}/runner-krunvm
       file: Dockerfile
     secrets:
       username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     with:
       image: ${{ github.actor }}/runner-krunvm
       file: Dockerfile
+      build-args: |
+        VERSION=${{ needs.build-base.outputs.version }}
     secrets:
       username: ${{ github.actor }}
       password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/build-two-images
 
 jobs:
   build-base:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/efrecon/runner-krunvm-base:main
+# syntax=docker/dockerfile:1
+ARG VERSION=main
+FROM ghcr.io/efrecon/runner-krunvm-base:${VERSION}
 
 ARG INSTALL_VERSION=latest
 ARG INSTALL_NAMESPACE=/opt/gh-runner-krunvm


### PR DESCRIPTION
This arranges for automatically building both images. A reusable workflow is created and used by both jobs -- one for each image to be created. The reusable workflow is almost generic and initial work has been made in order to be able to pull it out into another repository at a later time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a multi-platform Docker image building and pushing workflow, enhancing the CI/CD pipeline.
	- Updated the CI workflow to streamline the build process with improved job separation and dependency management.
	- Enhanced Dockerfile to allow dynamic specification of the base image version.

- **Chores**
	- Added new secrets for username and password to improve security in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->